### PR TITLE
Update js-to-dart.md - quickfix "increment a before b" example

### DIFF
--- a/src/_guides/language/coming-from/js-to-dart.md
+++ b/src/_guides/language/coming-from/js-to-dart.md
@@ -1006,7 +1006,7 @@ assert(5 % 2 == 1); // Remainder
 
 a = 0;
 b = ++a; // Increment a before b gets its value.
-assert(++a); // 1 == 1
+assert(a == b); // 1 == 1
 
 a = 0;
 b = a++; // Increment a AFTER b gets its value.


### PR DESCRIPTION
The PR fixes the small issue in the "js-to-dart" docs: it seems that an assertion in the "Increment a before b" example is incorrect.